### PR TITLE
Add pdm 1.0 license

### DIFF
--- a/OntoMetadataShape.ttl
+++ b/OntoMetadataShape.ttl
@@ -296,7 +296,9 @@ ontometa:OntologyMetadataShape a sh:NodeShape ;
             [sh:hasValue <http://creativecommons.org/licenses/by-sa/4.0/legalcode> ;] 
             [sh:hasValue <https://creativecommons.org/licenses/by-sa/4.0/legalcode> ;] 
             [sh:hasValue <http://creativecommons.org/licenses/by-sa/4.0/deed> ;] 
-            [sh:hasValue <https://creativecommons.org/licenses/by-sa/4.0/deed> ;] 
+            [sh:hasValue <https://creativecommons.org/licenses/by-sa/4.0/deed> ;]
+
+            [sh:hasValue <https://creativecommons.org/publicdomain/mark/1.0/> ;]
 
             # [sh:hasValue <> ;] 
             );

--- a/OntoMetadataShape4Forms.ttl
+++ b/OntoMetadataShape4Forms.ttl
@@ -111,6 +111,7 @@ ontometa4forms:OntologyMetadataShape a sh:NodeShape ;
             <https://opendatacommons.org/licenses/odbl/1-0/>
             <https://unlicense.org/>
             <https://creativecommons.org/publicdomain/zero/1.0/legalcode>
+            <https://creativecommons.org/publicdomain/mark/1.0>
             <https://creativecommons.org/licenses/by/3.0/legalcode>
             <https://creativecommons.org/licenses/by/4.0/legalcode>
             <https://creativecommons.org/licenses/by/3.0/de/legalcode>

--- a/OntoMetadataShape4TS.ttl
+++ b/OntoMetadataShape4TS.ttl
@@ -387,7 +387,7 @@ Example value: https://creativecommons.org/licenses/by/4.0/
             );
         sh:message """
 <p>
-The ontology declares a license which is not accepted at TIB Terminology Service. If you are the maintainer of the ontology, please consider, if the ontology can be provided with an open license. Read more about open licenses at https://opendefinition.org/licenses/. If the ontology license is open, but this test did not recognize it as such, please get in touch with us and it will be added to our list: https://github.com/TIBHannover/terminology-metadata/issues.
+The ontology declares a license which is not accepted at TIB Terminology Service. If you are the maintainer of the ontology, please consider, if the ontology can be provided with an open license. Read more about open licenses at https://opendefinition.org/licenses/. If the ontology license is open, but this test did not recognize it as such, please get in touch with us and it will be added to our list: https://github.com/TIBHannover/terminology-metadata/issues .
 </p>
 <p>
 Recommended property: http://purl.org/dc/terms/license

--- a/OntoMetadataShape4TS.ttl
+++ b/OntoMetadataShape4TS.ttl
@@ -379,7 +379,9 @@ Example value: https://creativecommons.org/licenses/by/4.0/
             [sh:hasValue <http://creativecommons.org/licenses/by-sa/4.0/legalcode> ;] 
             [sh:hasValue <https://creativecommons.org/licenses/by-sa/4.0/legalcode> ;] 
             [sh:hasValue <http://creativecommons.org/licenses/by-sa/4.0/deed> ;] 
-            [sh:hasValue <https://creativecommons.org/licenses/by-sa/4.0/deed> ;] 
+            [sh:hasValue <https://creativecommons.org/licenses/by-sa/4.0/deed> ;]
+
+            [sh:hasValue <https://creativecommons.org/publicdomain/mark/1.0/> ;]
 
             # [sh:hasValue <> ;] 
             );


### PR DESCRIPTION
This PR adresses #17 in that it adds https://creativecommons.org/publicdomain/mark/1.0/ to the known list of licenses.

This PR also adds a space in a link to the issues page of this repo, as it would otherwise be rendred wrong by the TS frontend, leading to a 404.